### PR TITLE
fix: don't recreate socket when language changes + other cleanups

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,5 @@
   "lint-staged": {
     "*": "prettier --ignore-unknown --write --ignore-path packages/backend/.prettierignore"
   },
-  "dependencies": {
-    "react-tabs": "^6.0.2"
-  }
+  "dependencies": {}
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,7 +18,9 @@
     "react-dom": "^18.3.1",
     "react-virtualized-auto-sizer": "^1.0.24",
     "react-window": "^1.8.10",
-    "socket.io-client": "^4.8.0"
+    "socket.io-client": "^4.8.0",
+    "react-tabs": "^6.0.2",
+    "use-effect-event": "^1.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",


### PR DESCRIPTION
the effect that creates the socket had `selectedLanguage` in dependencies, so we'd recreate the connection every time the language changed. i've cleaned up some of the logic so that we no longer do that

also now we store the data we have for each language (i.e. we keep a `Record<string, TopEmojis>` around). this has an interesting side effect -- when switching to a language that we've viewed before, we'll already have (old) data for it, so we'll flash all the emojis that updated since the tab switch. (this is easier to see than explain). i kinda like it but we can remove it if you don't @aliceisjustplaying 